### PR TITLE
CATS -> number of licenses

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="false" project-jdk-name="1.8-121" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/org/spectrumauctions/sats/core/api/CATSRegionsModelCreator.java
+++ b/src/main/java/org/spectrumauctions/sats/core/api/CATSRegionsModelCreator.java
@@ -13,22 +13,26 @@ import java.io.IOException;
 public class CATSRegionsModelCreator extends ModelCreator {
 
     private final int numberOfBidders;
+    private final int numberOfGoods;
 
     protected CATSRegionsModelCreator(Builder builder) {
         super(builder);
         this.numberOfBidders = builder.getNumberOfBidders();
+        this.numberOfGoods = builder.getNumberOfGoods();
     }
 
     @Override
     public PathResult generateResult(File outputFolder) throws UnsupportedBiddingLanguageException, IOException, IllegalConfigException {
         CATSRegionModel model = new CATSRegionModel();
         model.setNumberOfBidders(numberOfBidders);
+        model.setNumberOfGoods(numberOfGoods);
         return appendTopLevelParamsAndSolve(model, outputFolder);
     }
 
     public static class Builder extends ModelCreator.Builder{
 
         private int numberOfBidders;
+        private int numberOfGoods;
 
         public Builder() {
             super();
@@ -46,6 +50,14 @@ public class CATSRegionsModelCreator extends ModelCreator {
 
         public void setNumberOfBidders(int numberOfBidders) {
             this.numberOfBidders = numberOfBidders;
+        }
+
+        public int getNumberOfGoods() {
+            return numberOfGoods;
+        }
+
+        public void setNumberOfGoods(int numberOfGoods) {
+            this.numberOfGoods = numberOfGoods;
         }
     }
 }

--- a/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSRegionModel.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSRegionModel.java
@@ -1,6 +1,7 @@
 package org.spectrumauctions.sats.core.model.cats;
 
 import org.spectrumauctions.sats.core.model.DefaultModel;
+import org.spectrumauctions.sats.core.util.random.IntegerInterval;
 import org.spectrumauctions.sats.core.util.random.RNGSupplier;
 
 import java.util.ArrayList;
@@ -34,5 +35,9 @@ public class CATSRegionModel extends DefaultModel<CATSWorld, CATSBidder> {
 
     public void setNumberOfBidders(int numberOfBidders) {
         bidderBuilder.setNumberOfBidders(numberOfBidders);
+    }
+
+    public void setNumberOfGoods(int numberOfGoods) {
+        worldSetupBuilder.setNumberOfGoodsInterval(new IntegerInterval(numberOfGoods));
     }
 }

--- a/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSWorld.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSWorld.java
@@ -26,8 +26,15 @@ public final class CATSWorld extends World {
 
     public CATSWorld(CATSWorldSetup worldSetup, RNGSupplier rngSupplier) {
         super(MODEL_NAME);
-        int numberOfRows = worldSetup.drawNumberOfRows(rngSupplier);
-        int numberOfColumns = worldSetup.drawNumberOfColumns(rngSupplier);
+        int numberOfRows, numberOfColumns;
+        if (worldSetup.hasDefinedNumberOfGoodsInterval()) {
+            int numberOfGoods = worldSetup.drawNumberOfGoods(rngSupplier);
+            numberOfRows = (int) Math.floor(Math.sqrt(numberOfGoods));
+            numberOfColumns = (int) Math.floor(Math.sqrt(numberOfGoods));
+        } else {
+            numberOfRows = worldSetup.drawNumberOfRows(rngSupplier);
+            numberOfColumns = worldSetup.drawNumberOfColumns(rngSupplier);
+        }
         this.grid = worldSetup.buildProximityGraph(numberOfRows, numberOfColumns, rngSupplier);
         this.licenses = new HashSet<>();
         for (Vertex vertex : this.grid.getVertices()) {

--- a/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSWorldSetup.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSWorldSetup.java
@@ -15,6 +15,7 @@ public class CATSWorldSetup {
 
     private final IntegerInterval numberOfRowsInterval;
     private final IntegerInterval numberOfColumnInterval;
+    private final IntegerInterval numberOfGoodsInterval;
     private final DoubleInterval commonValueInterval;
 
     private final double threeProb;         //Probability of removing an edge adjacent to a particular vertex
@@ -27,6 +28,7 @@ public class CATSWorldSetup {
         super();
         this.numberOfRowsInterval = builder.numberOfRowsInterval;
         this.numberOfColumnInterval = builder.numberOfColumnsInterval;
+        this.numberOfGoodsInterval = builder.numberOfGoodsInterval;
         this.threeProb = builder.threeProb;
         this.additionalNeigh = builder.additionalNeigh;
         this.commonValueInterval = builder.commonValueInterval;
@@ -34,9 +36,18 @@ public class CATSWorldSetup {
         this.useQuadraticPricingOption = builder.useQuadraticPricingOption;
     }
 
-
     public double getAdditivity() {
         return additivity;
+    }
+
+    /**
+     * If the numberOfGoodsInterval is set, the number of rows and columns are ignored and the determination of those
+     * falls back to the CATS definition (int) Math.floor(Math.sqrt(numberOfGoods)).
+     *
+     * @return whether the numberOfGoodsInterval has been defined
+     */
+    public boolean hasDefinedNumberOfGoodsInterval() {
+        return this.numberOfGoodsInterval != null;
     }
 
     Integer drawNumberOfRows(RNGSupplier rngSupplier) {
@@ -47,6 +58,11 @@ public class CATSWorldSetup {
     Integer drawNumberOfColumns(RNGSupplier rngSupplier) {
         UniformDistributionRNG rng = rngSupplier.getUniformDistributionRNG();
         return rng.nextInt(numberOfColumnInterval);
+    }
+
+    Integer drawNumberOfGoods(RNGSupplier rngSupplier) {
+        UniformDistributionRNG rng = rngSupplier.getUniformDistributionRNG();
+        return rng.nextInt(numberOfGoodsInterval);
     }
 
     Double drawCommonValue(RNGSupplier rngSupplier) {
@@ -114,6 +130,7 @@ public class CATSWorldSetup {
         private DoubleInterval commonValueInterval;
         private IntegerInterval numberOfRowsInterval;
         private IntegerInterval numberOfColumnsInterval;
+        private IntegerInterval numberOfGoodsInterval;
         private double threeProb;
         private double additionalNeigh;
         private double additivity;
@@ -138,6 +155,11 @@ public class CATSWorldSetup {
         public void setNumberOfColumnsInterval(IntegerInterval numberOfColumnsInterval) {
             Preconditions.checkArgument(numberOfColumnsInterval.getMinValue() > 0);
             this.numberOfColumnsInterval = numberOfColumnsInterval;
+        }
+
+        public void setNumberOfGoodsInterval(IntegerInterval NumberOfGoodsInterval) {
+            Preconditions.checkArgument(numberOfColumnsInterval.getMinValue() > 0);
+            this.numberOfGoodsInterval = NumberOfGoodsInterval;
         }
 
         public void setCommonValueInterval(DoubleInterval commonValueInterval) {

--- a/src/test/java/org/spectrumauctions/sats/core/TestSuite.java
+++ b/src/test/java/org/spectrumauctions/sats/core/TestSuite.java
@@ -20,7 +20,9 @@ import org.spectrumauctions.sats.core.model.bvm.BMValueTest;
 import org.spectrumauctions.sats.core.model.bvm.SizeOrderedIteratorTest;
 import org.spectrumauctions.sats.core.model.bvm.SizeOrderedPowersetTest;
 import org.spectrumauctions.sats.core.model.bvm.bvm.BaseValueModel;
+import org.spectrumauctions.sats.core.model.cats.CATSBidderTest;
 import org.spectrumauctions.sats.core.model.cats.CATSRegionModel;
+import org.spectrumauctions.sats.core.model.cats.CATSWorldTest;
 import org.spectrumauctions.sats.core.model.gsvm.GSVMBidderTest;
 import org.spectrumauctions.sats.core.model.gsvm.GSVMWorldTest;
 import org.spectrumauctions.sats.core.model.lsvm.LSVMBidderTest;
@@ -75,6 +77,8 @@ import java.util.List;
         MRVMWorldTest.class,
         SRMTest.class,
         SRVMRandomnessTest.class,
+        CATSWorldTest.class,
+        CATSBidderTest.class,
         // Examples
         BiddingLanguagesExample.class,
         ParameterizingModelsExample.class,

--- a/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSBidderTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSBidderTest.java
@@ -92,7 +92,7 @@ public class CATSBidderTest {
             expectedValue += customPopulation.get(0).getPrivateValues().get(license.getId()).floatValue();
         }
 
-        Assert.assertEquals(value.floatValue(), expectedValue, 0.01f);
+        Assert.assertEquals(value.floatValue(), expectedValue, 0.1);
     }
 
     // ------- Helpers ------- //

--- a/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSWorldTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSWorldTest.java
@@ -43,6 +43,7 @@ public class CATSWorldTest {
         CATSWorld world1 = new CATSWorld(builder.build(), new JavaUtilRNGSupplier());
         Set<CATSLicense> licenses = world1.getLicenses();
         Assert.assertTrue(licenses.size() == 15);
+        Assert.assertFalse(world1.getUseQuadraticPricingOption());
     }
 
     /**
@@ -63,6 +64,28 @@ public class CATSWorldTest {
         Set<CATSLicense> licenses = world1.getLicenses();
         Assert.assertEquals(licenses.size(), 6);
         Assert.assertEquals(world1.getAdditivity(), 0.5, 0);
-        Assert.assertEquals(world1.getUseQuadraticPricingOption(), false);
+        Assert.assertTrue(world1.getUseQuadraticPricingOption());
+    }
+
+    /**
+     * Checks if highly customized world with a defined number of licenses is set up correctly
+     */
+    @Test
+    public void customWorldDefinedNumberOfLicensesSetUpCorrectly() {
+        CATSWorldSetup.Builder builder = new CATSWorldSetup.Builder();
+
+        // Single value as interval
+        builder.setNumberOfRowsInterval(new IntegerInterval(3));
+        builder.setNumberOfColumnsInterval(new IntegerInterval(2));
+        builder.setAdditionalNeigh(5);
+        builder.setAdditivity(0.5);
+        builder.setCommonValueInterval(new DoubleInterval(0, 5));
+        builder.setUseQuadraticPricingOption(true);
+        builder.setNumberOfGoodsInterval(new IntegerInterval(25));
+        CATSWorld world1 = new CATSWorld(builder.build(), new JavaUtilRNGSupplier());
+        Set<CATSLicense> licenses = world1.getLicenses();
+        Assert.assertEquals(licenses.size(), 25);
+        Assert.assertEquals(world1.getAdditivity(), 0.5, 0);
+        Assert.assertTrue(world1.getUseQuadraticPricingOption());
     }
 }

--- a/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSWorldTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/cats/CATSWorldTest.java
@@ -88,4 +88,24 @@ public class CATSWorldTest {
         Assert.assertEquals(world1.getAdditivity(), 0.5, 0);
         Assert.assertTrue(world1.getUseQuadraticPricingOption());
     }
+
+    /**
+     * Checks if standard world with a defined number of licenses is set up correctly
+     */
+    @Test
+    public void standardWorldDefinedNumberOfLicensesSetUpCorrectly() {
+        // Directly create standard world through model
+        CATSRegionModel model = new CATSRegionModel();
+        model.setNumberOfGoods(36);
+        CATSWorld world1 = model.createWorld(new JavaUtilRNGSupplier(983742L));
+
+        // Create standard world with a builder
+        CATSWorldSetup.Builder builder = new CATSWorldSetup.Builder();
+        builder.setNumberOfGoodsInterval(new IntegerInterval(36));
+        CATSWorld world2 = new CATSWorld(builder.build(), new JavaUtilRNGSupplier(983742L));
+
+        // Assert that this makes no difference
+        Assert.assertEquals(world1, world2);
+        Assert.assertEquals(36, world1.getNumberOfGoods());
+    }
 }


### PR DESCRIPTION
In CATS it's now possible to define the number of licenses, which ignores the set number of columns and rows and does it in the old-school CATS way.